### PR TITLE
chore: bump version to v0.0.21 so PyPI actually receives OA 0.21.22

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # Release History - `open-autonomy`
 
+# 0.0.21 (2026-05-20)
+
+* open-autonomy version v0.21.22.
+
 # 0.0.14 (2024-11-19)
 
 * open-autonomy version v0.18.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "propel-client"
-version = "v0.0.20"
+version = "v0.0.21"
 description = "Propel service client"
 authors = ["Yuri Turchenkov <yuri.turchenkov@valory.xyz>"]
 readme = "README.md"


### PR DESCRIPTION
## Summary

PR #18 (`chore: bump open-autonomy 0.21.14 → 0.21.22`) was tagged as `v0.0.21` and `Release Flow` succeeded — **but `pyproject.toml` was still pinned at `version = "v0.0.20"`**, so Poetry built `propel_client-0.0.20.{whl,tar.gz}` and twine skipped the upload with:

```
WARNING  Skipping propel_client-0.0.20-py3-none-any.whl because it appears to already exist
WARNING  Skipping propel_client-0.0.20.tar.gz       because it appears to already exist
```

PyPI still serves `v0.0.20`, which pins `open-autonomy==0.21.14` and forces every downstream consumer (mech-deployments etc.) to keep `uv pip install --prerelease=allow` for the transitive `ipfshttpclient>=0.8.0a2` that `0.21.14`'s `open-aea-cli-ipfs==2.1.0` dragged in.

This PR:
- Bumps `pyproject.toml` `version`: `v0.0.20` → `v0.0.21`.
- Adds a `0.0.21` entry to `HISTORY.md`.

## After merge — required release steps

The existing `v0.0.21` git tag (currently on `ff682c02`, the dud commit) needs to be deleted and re-cut on the merge commit:

```bash
git push --delete origin v0.0.21
git tag -d v0.0.21
git fetch
git tag v0.0.21 <merge-commit>
git push origin v0.0.21
```

(or just delete the existing GitHub release + tag from the UI and tag fresh.)

Release Flow will then re-run against a `pyproject.toml` that actually says `version = "v0.0.21"`, `twine` will publish `propel_client-0.0.21.{whl,tar.gz}` cleanly, and downstream repos can drop `--prerelease=allow`.

## Note on the stale branch

There's also a leftover `chore/bump-v0.0.22` branch on origin from an earlier draft of this PR (before we decided to keep the `v0.0.21` numbering). Safe to delete.

## Test plan

- [ ] CI passes on this branch.
- [ ] After merge: existing `v0.0.21` tag deleted and re-cut on the new merge commit.
- [ ] `pip install propel-client==0.0.21` works from PyPI.
- [ ] Downstream `uv pip install … propel-client` resolves without `--prerelease=allow`.
